### PR TITLE
Add working brickd.service file to linux install

### DIFF
--- a/src/build_data/linux/installer/lib/systemd/system/brickd.service
+++ b/src/build_data/linux/installer/lib/systemd/system/brickd.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Start the brickd daemon for Tinkerforge bricks
+
+[Service]
+User=root
+Type=forking
+ExecStart=/usr/bin/brickd --daemon
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This file was tested with Ubuntu 16.04.4 and can be used to start/stop
the brickd daemon via systemctl. It can also be used to autostart the
brickd daemon on boot.

This should close issue #11 