### PR TITLE
Listen on localhost instead of all available IPs

### DIFF
--- a/src/brickd/config_options.c
+++ b/src/brickd/config_options.c
@@ -48,7 +48,7 @@ static const char *config_format_red_led_trigger(int value) {
 #endif
 
 ConfigOption config_options[] = {
-	CONFIG_OPTION_STRING_INITIALIZER("listen.address", 1, -1, "0.0.0.0"),
+	CONFIG_OPTION_STRING_INITIALIZER("listen.address", 1, -1, "127.0.0.1"),
 	CONFIG_OPTION_INTEGER_INITIALIZER("listen.plain_port", 1, UINT16_MAX, 4223),
 	CONFIG_OPTION_INTEGER_INITIALIZER("listen.websocket_port", 0, UINT16_MAX, 0), // default to enable: 4280
 	CONFIG_OPTION_INTEGER_INITIALIZER("listen.mesh_gateway_port", 1, UINT16_MAX, 4240),

--- a/src/build_data/linux/installer/etc/brickd-default.conf
+++ b/src/build_data/linux/installer/etc/brickd-default.conf
@@ -22,8 +22,8 @@
 # Bricks and Bricklets connected to it. We strongly recommend that you enable
 # authentication if you enabled WebSocket support.
 #
-# The default values are 0.0.0.0, 4223, 0 (disabled), 4240 and off.
-listen.address = 0.0.0.0
+# The default values are 127.0.0.1, 4223, 0 (disabled), 4240 and off.
+listen.address = 127.0.0.1
 listen.plain_port = 4223
 listen.websocket_port = 0
 listen.mesh_gateway_port = 4240

--- a/src/build_data/linux/installer/etc/brickd-red-brick.conf
+++ b/src/build_data/linux/installer/etc/brickd-red-brick.conf
@@ -22,8 +22,8 @@
 # Bricks and Bricklets connected to it. We strongly recommend that you enable
 # authentication if you enabled WebSocket support.
 #
-# The default values are 0.0.0.0, 4223, 0 (disabled), 4240 and off.
-listen.address = 0.0.0.0
+# The default values are 127.0.0.1, 4223, 0 (disabled), 4240 and off.
+listen.address = 127.0.0.1
 listen.plain_port = 4223
 listen.websocket_port = 0
 listen.mesh_gateway_port = 4240

--- a/src/build_data/linux/installer/usr/share/man/man5/brickd.conf.5
+++ b/src/build_data/linux/installer/usr/share/man/man5/brickd.conf.5
@@ -44,7 +44,7 @@ connections.
 binds a plain TCP/IP socket and a WebSocket to this address to listen for
 incoming plain TCP/IP and WebSocket connections. The address can either be a
 dotted-decimal IPv4 address or a hexadecimal IPv6 address. It can also be a
-hostname such as \fIlocalhost\fR. The default value is \fI0.0.0.0\fR.
+hostname such as \fIlocalhost\fR. The default value is \fI127.0.0.1\fR.
 .IP "\fBlisten.plain_port\fR" 4
 The port number to listen to for incoming plain TCP/IP connections. The default
 value is \fI4223\fR.

--- a/src/build_data/linux/installer/usr/share/man/man8/brickd.8
+++ b/src/build_data/linux/installer/usr/share/man/man8/brickd.8
@@ -22,7 +22,7 @@ available for various programming languages.
 Bricks connected to USB are identified using their vendor ID (16D0) and product
 IDs (063D and 09E5).
 .PP
-By default, brickd binds to 0.0.0.0 (IPv4) and listens on port 4223 for
+By default, brickd binds to 127.0.0.1 (IPv4) and listens on port 4223 for
 incoming TCP/IP connections. Listening for incoming WebSocket connections is
 disabled by default for security reasons. The bind address (IPv4 or IPv6),
 listen ports, dual-stack operation and WebSocket support can be configured in

--- a/src/build_data/macos/installer/root/etc/brickd.conf
+++ b/src/build_data/macos/installer/root/etc/brickd.conf
@@ -22,8 +22,8 @@
 # Bricks and Bricklets connected to it. We strongly recommend that you enable
 # authentication if you enabled WebSocket support.
 #
-# The default values are 0.0.0.0, 4223, 0 (disabled), 4240 and off.
-listen.address = 0.0.0.0
+# The default values are 127.0.0.1, 4223, 0 (disabled), 4240 and off.
+listen.address = 127.0.0.1
 listen.plain_port = 4223
 listen.websocket_port = 0
 listen.mesh_gateway_port = 4240

--- a/src/build_data/windows/brickd.ini
+++ b/src/build_data/windows/brickd.ini
@@ -23,7 +23,7 @@
 # authentication if you enabled WebSocket support.
 #
 # The default values are 0.0.0.0, 4223, 0 (disabled), 4240 and off.
-listen.address = 0.0.0.0
+listen.address = 127.0.0.1
 listen.plain_port = 4223
 listen.websocket_port = 0
 listen.mesh_gateway_port = 4240

--- a/src/build_data/windows/brickd.ini
+++ b/src/build_data/windows/brickd.ini
@@ -22,7 +22,7 @@
 # Bricks and Bricklets connected to it. We strongly recommend that you enable
 # authentication if you enabled WebSocket support.
 #
-# The default values are 0.0.0.0, 4223, 0 (disabled), 4240 and off.
+# The default values are 127.0.0.1, 4223, 0 (disabled), 4240 and off.
 listen.address = 127.0.0.1
 listen.plain_port = 4223
 listen.websocket_port = 0


### PR DESCRIPTION
For security reasons, i would prefer the brickd to listen on localhost as a default. A informed user can change it back (with security enabled) if required. For the simple use case of tinkering around for the first time this should be kind of an improvement.